### PR TITLE
fix: adding min price for starting the bids positions

### DIFF
--- a/src/concentratedLiquidity/positionViewer.ts
+++ b/src/concentratedLiquidity/positionViewer.ts
@@ -53,7 +53,9 @@ export abstract class PositionViewer {
         const bids: Position[] = [];
         const asks: Position[] = [];
 
-        while (startPrice < bestAskPrice) {
+        const maxPrice = Math.max(Number(bestAskPrice), Number(endPrice));
+
+        while (startPrice < maxPrice) {
             numBids++;
             var nextPrice = (startPrice * (FEE_DENOMINATOR + minFeesBps)) / FEE_DENOMINATOR;
             if (nextPrice == startPrice) {
@@ -268,10 +270,12 @@ export abstract class PositionViewer {
         const asks: Position[] = [];
         let currentPrice = startPrice;
 
+        const maxPrice = Math.min(Number(bestAskPrice), Number(endPrice));
+
         // #############################################################
         // # 1. Generate Bid & Ask Position Grids
         // #############################################################
-        while (currentPrice < bestAskPrice) {
+        while (currentPrice < maxPrice) {
             let nextPrice = (currentPrice * (FEE_DENOMINATOR + minFeesBps)) / FEE_DENOMINATOR;
             if (nextPrice === currentPrice) nextPrice = currentPrice + tickSize;
             nextPrice = nextPrice - (nextPrice % tickSize);
@@ -445,11 +449,13 @@ export abstract class PositionViewer {
 
         let currentPrice = startPrice;
 
+        const maxPrice = Math.min(Number(bestAskPrice), Number(endPrice));
+
         // #############################################################
         // # 1. Generate Bid & Ask Position Grids
         // #############################################################
         // Bids are created from the farthest price (startPrice) inwards to the center.
-        while (currentPrice < bestAskPrice) {
+        while (currentPrice < maxPrice) {
             let nextPrice = (currentPrice * (FEE_DENOMINATOR + minFeesBps)) / FEE_DENOMINATOR;
             if (nextPrice === currentPrice) nextPrice = currentPrice + tickSize;
             nextPrice = nextPrice - (nextPrice % tickSize);

--- a/src/concentratedLiquidity/positionViewer.ts
+++ b/src/concentratedLiquidity/positionViewer.ts
@@ -53,7 +53,7 @@ export abstract class PositionViewer {
         const bids: Position[] = [];
         const asks: Position[] = [];
 
-        const maxPrice = Math.max(Number(bestAskPrice), Number(endPrice));
+        const maxPrice = Math.min(Number(bestAskPrice), Number(endPrice));
 
         while (startPrice < maxPrice) {
             numBids++;


### PR DESCRIPTION
![CleanShot 2025-06-06 at 17 31 17@2x](https://github.com/user-attachments/assets/056905af-25e1-44be-9227-d4b6b9a8c28d)

The bids always starts from bestAskPrice even when it's a single side LP (Quote).
Instead it should start from the given `endPrice` when `endPrice < bestAskPrice`