### PR TITLE
fix: abstracted the bids & asks calculation

### DIFF
--- a/src/concentratedLiquidity/index.ts
+++ b/src/concentratedLiquidity/index.ts
@@ -1,4 +1,5 @@
+export * from './lpSummary';
+export * from './orderCalculator';
 export * from './positionViewer';
 export * from './provision';
 export * from './withdraw';
-export * from './lpSummary';

--- a/src/concentratedLiquidity/lpSummary.ts
+++ b/src/concentratedLiquidity/lpSummary.ts
@@ -1,4 +1,4 @@
-import { BatchLPDetails, Position } from './positionViewer';
+import { Position } from './positionViewer';
 
 export interface LPSummary {
     bids: Position[];
@@ -8,7 +8,8 @@ export interface LPSummary {
 }
 
 export async function getLPSummaryForMinSize(
-    batchLPDetails: BatchLPDetails,
+    bids: Position[],
+    asks: Position[],
     minSize: bigint,
     sizePrecision: bigint,
     pricePrecision: bigint,
@@ -16,7 +17,7 @@ export async function getLPSummaryForMinSize(
 ): Promise<LPSummary> {
     // Find smallest liquidity in bids
     let smallestBidSize: bigint | null = null;
-    for (const bid of batchLPDetails.bids) {
+    for (const bid of bids) {
         if (smallestBidSize === null || bid.liquidity < smallestBidSize) {
             smallestBidSize = bid.liquidity;
         }
@@ -24,14 +25,14 @@ export async function getLPSummaryForMinSize(
 
     // Find smallest liquidity in asks
     let smallestAskSize: bigint | null = null;
-    for (const ask of batchLPDetails.asks) {
+    for (const ask of asks) {
         if (smallestAskSize === null || ask.liquidity < smallestAskSize) {
             smallestAskSize = ask.liquidity;
         }
     }
 
     // Scale bids: replace smallest with minSize, scale others proportionally
-    const scaledBids: Position[] = batchLPDetails.bids.map((position) => {
+    const scaledBids: Position[] = bids.map((position) => {
         if (smallestBidSize === null || smallestBidSize === BigInt(0)) {
             return { ...position };
         }
@@ -44,7 +45,7 @@ export async function getLPSummaryForMinSize(
     });
 
     // Scale asks: replace smallest with minSize, scale others proportionally
-    const scaledAsks: Position[] = batchLPDetails.asks.map((position) => {
+    const scaledAsks: Position[] = asks.map((position) => {
         if (smallestAskSize === null || smallestAskSize === BigInt(0)) {
             return { ...position };
         }

--- a/src/concentratedLiquidity/orderCalculator.ts
+++ b/src/concentratedLiquidity/orderCalculator.ts
@@ -1,0 +1,173 @@
+import { Position } from './positionViewer';
+
+export const getBidsAndAsksForSpotLiquidity = (
+    bestAskPrice: bigint,
+    endPrice: bigint,
+    startPrice: bigint,
+    tickSize: bigint,
+    minFeesBps: bigint,
+    FEE_DENOMINATOR: bigint,
+) => {
+    const bids: Position[] = [];
+    const asks: Position[] = [];
+
+    const maxPrice = Math.min(Number(bestAskPrice), Number(endPrice));
+
+    while (startPrice < maxPrice) {
+        var nextPrice = (startPrice * (FEE_DENOMINATOR + minFeesBps)) / FEE_DENOMINATOR;
+        nextPrice = nextPrice - (nextPrice % tickSize);
+        if (nextPrice == startPrice) {
+            nextPrice = startPrice + tickSize;
+        }
+        var flipPrice = (nextPrice * (FEE_DENOMINATOR + minFeesBps)) / FEE_DENOMINATOR;
+        flipPrice = flipPrice - (flipPrice % tickSize);
+        if (flipPrice == nextPrice) {
+            flipPrice = nextPrice + tickSize;
+        }
+
+        const position = {
+            price: startPrice,
+            liquidity: BigInt(0),
+            flipPrice,
+        };
+        bids.push(position);
+
+        startPrice = nextPrice;
+    }
+
+    while (startPrice < endPrice) {
+        var flipPrice =
+            (startPrice * (FEE_DENOMINATOR - minFeesBps) * (FEE_DENOMINATOR - minFeesBps)) /
+            (FEE_DENOMINATOR * FEE_DENOMINATOR);
+        if (flipPrice == startPrice) {
+            flipPrice = startPrice - tickSize;
+        }
+        flipPrice = flipPrice - (flipPrice % tickSize);
+
+        const position = {
+            price: startPrice,
+            liquidity: BigInt(0),
+            flipPrice,
+        };
+        asks.push(position);
+
+        var nextPrice = (startPrice * (FEE_DENOMINATOR + minFeesBps)) / FEE_DENOMINATOR;
+        nextPrice = nextPrice - (nextPrice % tickSize);
+        if (nextPrice == startPrice) {
+            nextPrice = startPrice + tickSize;
+        }
+
+        startPrice = nextPrice;
+    }
+
+    return { bids, asks };
+};
+
+export const getBidsAndAsksForCurveLiquidity = (
+    bestAskPrice: bigint,
+    endPrice: bigint,
+    startPrice: bigint,
+    tickSize: bigint,
+    minFeesBps: bigint,
+    FEE_DENOMINATOR: bigint,
+) => {
+    const bids: Position[] = [];
+    const asks: Position[] = [];
+    let currentPrice = startPrice;
+
+    const maxPrice = Math.min(Number(bestAskPrice), Number(endPrice));
+
+    // #############################################################
+    // # 1. Generate Bid & Ask Position Grids
+    // #############################################################
+    while (currentPrice < maxPrice) {
+        let nextPrice = (currentPrice * (FEE_DENOMINATOR + minFeesBps)) / FEE_DENOMINATOR;
+        nextPrice = nextPrice - (nextPrice % tickSize);
+        if (nextPrice === currentPrice) nextPrice = currentPrice + tickSize;
+
+        var flipPrice = (nextPrice * (FEE_DENOMINATOR + minFeesBps)) / FEE_DENOMINATOR;
+        flipPrice = flipPrice - (flipPrice % tickSize);
+        if (flipPrice == nextPrice) {
+            flipPrice = nextPrice + tickSize;
+        }
+
+        bids.push({ price: currentPrice, liquidity: BigInt(0), flipPrice });
+        currentPrice = nextPrice;
+    }
+
+    while (currentPrice < endPrice) {
+        var flipPrice =
+            (currentPrice * (FEE_DENOMINATOR - minFeesBps) * (FEE_DENOMINATOR - minFeesBps)) /
+            (FEE_DENOMINATOR * FEE_DENOMINATOR);
+        if (flipPrice == currentPrice) {
+            flipPrice = currentPrice - tickSize;
+        }
+        flipPrice = flipPrice - (flipPrice % tickSize);
+
+        asks.push({ price: currentPrice, liquidity: BigInt(0), flipPrice });
+
+        let nextPrice = (currentPrice * (FEE_DENOMINATOR + minFeesBps)) / FEE_DENOMINATOR;
+        nextPrice = nextPrice - (nextPrice % tickSize);
+        if (nextPrice === currentPrice) nextPrice = currentPrice + tickSize;
+
+        currentPrice = nextPrice;
+    }
+
+    return { bids, asks };
+};
+
+export const getBidsAndAsksForBidAskLiquidity = (
+    bestAskPrice: bigint,
+    endPrice: bigint,
+    startPrice: bigint,
+    tickSize: bigint,
+    minFeesBps: bigint,
+    FEE_DENOMINATOR: bigint,
+) => {
+    const bids: Position[] = [];
+    const asks: Position[] = [];
+
+    let currentPrice = startPrice;
+
+    const maxPrice = Math.min(Number(bestAskPrice), Number(endPrice));
+
+    // #############################################################
+    // # 1. Generate Bid & Ask Position Grids
+    // #############################################################
+    // Bids are created from the farthest price (startPrice) inwards to the center.
+    while (currentPrice < maxPrice) {
+        let nextPrice = (currentPrice * (FEE_DENOMINATOR + minFeesBps)) / FEE_DENOMINATOR;
+        nextPrice = nextPrice - (nextPrice % tickSize);
+        if (nextPrice === currentPrice) nextPrice = currentPrice + tickSize;
+
+        var flipPrice = (nextPrice * (FEE_DENOMINATOR + minFeesBps)) / FEE_DENOMINATOR;
+        flipPrice = flipPrice - (flipPrice % tickSize);
+        if (flipPrice == nextPrice) {
+            flipPrice = nextPrice + tickSize;
+        }
+
+        bids.push({ price: currentPrice, liquidity: BigInt(0), flipPrice });
+        currentPrice = nextPrice;
+    }
+
+    // Asks are created from the center outwards to the farthest price (endPrice).
+    while (currentPrice < endPrice) {
+        var flipPrice =
+            (currentPrice * (FEE_DENOMINATOR - minFeesBps) * (FEE_DENOMINATOR - minFeesBps)) /
+            (FEE_DENOMINATOR * FEE_DENOMINATOR);
+        if (flipPrice == currentPrice) {
+            flipPrice = currentPrice - tickSize;
+        }
+        flipPrice = flipPrice - (flipPrice % tickSize);
+
+        asks.push({ price: currentPrice, liquidity: BigInt(0), flipPrice });
+
+        let nextPrice = (currentPrice * (FEE_DENOMINATOR + minFeesBps)) / FEE_DENOMINATOR;
+        nextPrice = nextPrice - (nextPrice % tickSize);
+        if (nextPrice === currentPrice) nextPrice = currentPrice + tickSize;
+
+        currentPrice = nextPrice;
+    }
+
+    return { bids, asks };
+};

--- a/src/concentratedLiquidity/positionViewer.ts
+++ b/src/concentratedLiquidity/positionViewer.ts
@@ -1,4 +1,9 @@
 import { LPSummary, getLPSummaryForMinSize } from './lpSummary';
+import {
+    getBidsAndAsksForBidAskLiquidity,
+    getBidsAndAsksForCurveLiquidity,
+    getBidsAndAsksForSpotLiquidity,
+} from './orderCalculator';
 
 // ============ Types ============
 export interface BatchLPDetails {
@@ -119,57 +124,14 @@ export abstract class PositionViewer {
             startPrice = startPrice - (startPrice % tickSize) + tickSize;
         }
 
-        const bids: Position[] = [];
-        const asks: Position[] = [];
-
-        const maxPrice = Math.min(Number(bestAskPrice), Number(endPrice));
-
-        while (startPrice < maxPrice) {
-            var nextPrice = (startPrice * (FEE_DENOMINATOR + minFeesBps)) / FEE_DENOMINATOR;
-            nextPrice = nextPrice - (nextPrice % tickSize);
-            if (nextPrice == startPrice) {
-                nextPrice = startPrice + tickSize;
-            }
-            var flipPrice = (nextPrice * (FEE_DENOMINATOR + minFeesBps)) / FEE_DENOMINATOR;
-            flipPrice = flipPrice - (flipPrice % tickSize);
-            if (flipPrice == nextPrice) {
-                flipPrice = nextPrice + tickSize;
-            }
-
-            const position = {
-                price: startPrice,
-                liquidity: BigInt(0),
-                flipPrice,
-            };
-            bids.push(position);
-
-            startPrice = nextPrice;
-        }
-
-        while (startPrice < endPrice) {
-            var flipPrice =
-                (startPrice * (FEE_DENOMINATOR - minFeesBps) * (FEE_DENOMINATOR - minFeesBps)) /
-                (FEE_DENOMINATOR * FEE_DENOMINATOR);
-            if (flipPrice == startPrice) {
-                flipPrice = startPrice - tickSize;
-            }
-            flipPrice = flipPrice - (flipPrice % tickSize);
-
-            const position = {
-                price: startPrice,
-                liquidity: BigInt(0),
-                flipPrice,
-            };
-            asks.push(position);
-
-            var nextPrice = (startPrice * (FEE_DENOMINATOR + minFeesBps)) / FEE_DENOMINATOR;
-            nextPrice = nextPrice - (nextPrice % tickSize);
-            if (nextPrice == startPrice) {
-                nextPrice = startPrice + tickSize;
-            }
-
-            startPrice = nextPrice;
-        }
+        const { bids, asks } = getBidsAndAsksForSpotLiquidity(
+            bestAskPrice,
+            endPrice,
+            startPrice,
+            tickSize,
+            minFeesBps,
+            FEE_DENOMINATOR,
+        );
 
         const numBids = BigInt(bids.length);
         const numAsks = BigInt(asks.length);
@@ -205,7 +167,8 @@ export abstract class PositionViewer {
                 minSizeError: minSizeError,
             };
             const lpSummary = await getLPSummaryForMinSize(
-                batchLPDetails,
+                bids,
+                asks,
                 minSize,
                 sizePrecision,
                 pricePrecision,
@@ -289,7 +252,8 @@ export abstract class PositionViewer {
                 minSizeError: minSizeError,
             };
             const lpSummary = await getLPSummaryForMinSize(
-                batchLPDetails,
+                bids,
+                asks,
                 minSize,
                 sizePrecision,
                 pricePrecision,
@@ -324,7 +288,8 @@ export abstract class PositionViewer {
                 minSizeError: minSizeError,
             };
             const lpSummary = await getLPSummaryForMinSize(
-                batchLPDetails,
+                bids,
+                asks,
                 minSize,
                 sizePrecision,
                 pricePrecision,
@@ -341,7 +306,8 @@ export abstract class PositionViewer {
             minSizeError: minSizeError,
         };
         const lpSummary = await getLPSummaryForMinSize(
-            batchLPDetails,
+            [],
+            [],
             minSize,
             sizePrecision,
             pricePrecision,
@@ -416,47 +382,14 @@ export abstract class PositionViewer {
             startPrice = startPrice - (startPrice % tickSize) + tickSize;
         }
 
-        const bids: Position[] = [];
-        const asks: Position[] = [];
-        let currentPrice = startPrice;
-
-        const maxPrice = Math.min(Number(bestAskPrice), Number(endPrice));
-
-        // #############################################################
-        // # 1. Generate Bid & Ask Position Grids
-        // #############################################################
-        while (currentPrice < maxPrice) {
-            let nextPrice = (currentPrice * (FEE_DENOMINATOR + minFeesBps)) / FEE_DENOMINATOR;
-            nextPrice = nextPrice - (nextPrice % tickSize);
-            if (nextPrice === currentPrice) nextPrice = currentPrice + tickSize;
-
-            var flipPrice = (nextPrice * (FEE_DENOMINATOR + minFeesBps)) / FEE_DENOMINATOR;
-            flipPrice = flipPrice - (flipPrice % tickSize);
-            if (flipPrice == nextPrice) {
-                flipPrice = nextPrice + tickSize;
-            }
-
-            bids.push({ price: currentPrice, liquidity: BigInt(0), flipPrice });
-            currentPrice = nextPrice;
-        }
-
-        while (currentPrice < endPrice) {
-            var flipPrice =
-                (currentPrice * (FEE_DENOMINATOR - minFeesBps) * (FEE_DENOMINATOR - minFeesBps)) /
-                (FEE_DENOMINATOR * FEE_DENOMINATOR);
-            if (flipPrice == currentPrice) {
-                flipPrice = currentPrice - tickSize;
-            }
-            flipPrice = flipPrice - (flipPrice % tickSize);
-
-            asks.push({ price: currentPrice, liquidity: BigInt(0), flipPrice });
-
-            let nextPrice = (currentPrice * (FEE_DENOMINATOR + minFeesBps)) / FEE_DENOMINATOR;
-            nextPrice = nextPrice - (nextPrice % tickSize);
-            if (nextPrice === currentPrice) nextPrice = currentPrice + tickSize;
-
-            currentPrice = nextPrice;
-        }
+        const { bids, asks } = getBidsAndAsksForCurveLiquidity(
+            bestAskPrice,
+            endPrice,
+            startPrice,
+            tickSize,
+            minFeesBps,
+            FEE_DENOMINATOR,
+        );
 
         const numBids = BigInt(bids.length);
         const numAsks = BigInt(asks.length);
@@ -581,7 +514,8 @@ export abstract class PositionViewer {
             minSizeError: minSizeError,
         };
         const lpSummary = await getLPSummaryForMinSize(
-            batchLPDetails,
+            bids,
+            asks,
             minSize,
             sizePrecision,
             pricePrecision,
@@ -658,50 +592,14 @@ export abstract class PositionViewer {
             startPrice = startPrice - (startPrice % tickSize) + tickSize;
         }
 
-        const bids: Position[] = [];
-        const asks: Position[] = [];
-
-        let currentPrice = startPrice;
-
-        const maxPrice = Math.min(Number(bestAskPrice), Number(endPrice));
-
-        // #############################################################
-        // # 1. Generate Bid & Ask Position Grids
-        // #############################################################
-        // Bids are created from the farthest price (startPrice) inwards to the center.
-        while (currentPrice < maxPrice) {
-            let nextPrice = (currentPrice * (FEE_DENOMINATOR + minFeesBps)) / FEE_DENOMINATOR;
-            nextPrice = nextPrice - (nextPrice % tickSize);
-            if (nextPrice === currentPrice) nextPrice = currentPrice + tickSize;
-
-            var flipPrice = (nextPrice * (FEE_DENOMINATOR + minFeesBps)) / FEE_DENOMINATOR;
-            flipPrice = flipPrice - (flipPrice % tickSize);
-            if (flipPrice == nextPrice) {
-                flipPrice = nextPrice + tickSize;
-            }
-
-            bids.push({ price: currentPrice, liquidity: BigInt(0), flipPrice });
-            currentPrice = nextPrice;
-        }
-
-        // Asks are created from the center outwards to the farthest price (endPrice).
-        while (currentPrice < endPrice) {
-            var flipPrice =
-                (currentPrice * (FEE_DENOMINATOR - minFeesBps) * (FEE_DENOMINATOR - minFeesBps)) /
-                (FEE_DENOMINATOR * FEE_DENOMINATOR);
-            if (flipPrice == currentPrice) {
-                flipPrice = currentPrice - tickSize;
-            }
-            flipPrice = flipPrice - (flipPrice % tickSize);
-
-            asks.push({ price: currentPrice, liquidity: BigInt(0), flipPrice });
-
-            let nextPrice = (currentPrice * (FEE_DENOMINATOR + minFeesBps)) / FEE_DENOMINATOR;
-            nextPrice = nextPrice - (nextPrice % tickSize);
-            if (nextPrice === currentPrice) nextPrice = currentPrice + tickSize;
-
-            currentPrice = nextPrice;
-        }
+        const { bids, asks } = getBidsAndAsksForBidAskLiquidity(
+            bestAskPrice,
+            endPrice,
+            startPrice,
+            tickSize,
+            minFeesBps,
+            FEE_DENOMINATOR,
+        );
 
         const numBids = BigInt(bids.length);
         const numAsks = BigInt(asks.length);
@@ -843,7 +741,8 @@ export abstract class PositionViewer {
             minSizeError: minSizeError,
         };
         const lpSummary = await getLPSummaryForMinSize(
-            batchLPDetails,
+            bids,
+            asks,
             minSize,
             sizePrecision,
             pricePrecision,


### PR DESCRIPTION
Abstracted out the calculation of bids and asks to be able to estimate the min required quote and base liquidity

## Flow

We are already calculating the min and max prices for `x` prices points.

with required bids and asks, we'll be able to estimate the min required quote and base liquidity for a pair using `getLPSummaryForMinSize`